### PR TITLE
Default Dark color scheme

### DIFF
--- a/Default Dark
+++ b/Default Dark
@@ -1,0 +1,325 @@
+{
+    "name": "Xcode Default (Dark)",
+    "author": "Kees van Beilen, inspired by Apple",
+    "variables":
+    {
+        //These colors where extracted from the xcode color plist file and are 99% accurate.
+        "plain_text"                    : "#FFF",     // white
+        "comments"                      : "#6c7986",  // grey
+        "documentation_markup"          : "#6c7986",  // grey
+        "documentation_markup_keywords" : "#92a1b1",  // light-grey
+        "strings"                       : "#fc6a5d",  // orange
+        "characters"                    : "#d0bf69",  // yellow
+        "numbers"                       : "#d0bf69",  // yellow
+        "keywords"                      : "#fc5fa3",  // pink
+        "preprocessor_statements"       : "#fd8f3f",  // light brown
+        "urls"                          : "#5482ff",  // cold blue
+        "attributes"                    : "#bf8555",  // brown
+        "project_class_names"           : "#9ef1dd",  // light bondi
+        "project_method_names"          : "#67b7a4",  // dark bondi
+        "project_constants"             : "#67b7a4",  // dark bondi
+        "project_type_names"            : "#9ef1dd",  // light bondi
+        "project_variables"             : "#67b7a4",  // light bondi
+        "project_preprocessor_macros"   : "#fd8f3f",  // light brown
+        "other_class_names"             : "#d0a8ff",  // light purple
+        "other_method_names"            : "#a167e6",  // purple
+        "other_constants"               : "#a167e6",  // purple
+        "other_type_names"              : "#d0a8ff",  // light purple
+        "other_variables"               : "#a167e6",  // light purple
+        "other_preprocessor_macros"     : "#fd8f3f",  // dark brown
+        //These where color picked and made a bit more brighter.
+        "background"                    : "#2E2F39",  // dark grey
+        "current_line"                  : "#383D46",  // grey
+        "selection"                     : "#595B5A",  // light grey
+        "cursor"                        : "#FFF",     // white
+        "invisibles"                    : "#27262E",  // grey
+
+        "embedded": "color(var(background) blend(var(invisibles) 86%))",
+        "invalid": "var(strings)",
+    },
+    "globals":
+    {
+        "foreground": "var(plain_text)",
+        "background": "var(background)",
+        "caret": "var(cursor)",
+        "line_highlight": "var(current_line)",
+        "selection": "var(selection)",
+        "selection_border": "color(var(selection) blend(#000 92%)",
+        "inactive_selection": "color(var(selection) blend(var(background) 72%)",
+        "misspelling": "var(strings)",
+        "shadow": "color(var(background) blend(#000 50%))"
+    },
+    "rules":
+    [
+        {
+            "name": "Error",
+            "scope": "markup.error",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Warning",
+            "scope": "markup.warning",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Parameters",
+            "scope": "variable.parameter",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.definition",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword, keyword.operator.word",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword.control.import",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Variables",
+            "scope": "variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Variable function",
+            "scope": "variable.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Functions",
+            "scope": "entity.name.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label)",
+            "foreground": "var(project_class_names)"
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Support Functions",
+            "scope": "support.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function.member",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "Support Classes",
+            "scope": "support.class",
+            "foreground": "var(other_class_names)"
+        },
+        {
+            "name": "Support Constants",
+            "scope": "support.constant, constant.language",
+            "foreground": "var(keywords)",
+            "font_style": "italic"
+        },
+        {
+            "name": "CSS Support Constants",
+            "scope": "source.css support.constant",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Strings, Inherited Class",
+            "scope": "string, entity.other.inherited-class",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "string punctuation.definition.string",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Variables in Strings",
+            "scope": "string variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.separator, punctuation.terminator, punctuation.accessor",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.section",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "foreground": "var(numbers)"
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "foreground": "var(project_constants)"
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Types",
+            "scope": "entity.name.type",
+            "foreground": "var(project_type_names)"
+        },
+        {
+            "name": "Types",
+            "scope": "support.type",
+            "foreground": "var(other_type_names)"
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "foreground": "var(project_constants)",
+            "font_style": "bold"
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold",
+            "font_style": "bold"
+        },
+        {
+            "name": "Italic",
+            "scope": "markup.italic",
+            "font_style": "italic"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw.inline",
+            "foreground": "var(preprocessor_statements)",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "markup.raw.inline punctuation.definition.raw",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Link Text",
+            "scope": "string.other.link, markup.underline.link",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Lists",
+            "scope": "punctuation.definition.list_item, markup.list.numbered.bullet",
+            "foreground": "var(documentation_markup)"
+        },
+        {
+            "name": "Quotes",
+            "scope": "punctuation.definition.blockquote",
+            "background": "var(invisibles)"
+        },
+        {
+            "name": "Link/Image Punctuation",
+            "scope": "punctuation.definition.image, punctuation.definition.link, punctuation.definition.metadata",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Inserted",
+            "scope": "markup.inserted",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Deleted",
+            "scope": "markup.deleted",
+            "foreground": "var(invalid)"
+        },
+        {
+            "name": "Changed",
+            "scope": "markup.changed",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Colors",
+            "scope": "constant.other.color",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions Operator",
+            "scope": "string.regexp keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "YAML String",
+            "scope": "source.yaml string.unquoted",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Embedded",
+            "scope": "punctuation.section.embedded",
+            "foreground": "var(embedded)"
+        },
+        {
+            "name": "Embedded Variable",
+            "scope": "variable.interpolation",
+            "foreground": "var(project_preprocessor_macros)"
+        },
+        {
+            "name": "Illegal",
+            "scope": "invalid.illegal",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Invalid deprecated",
+            "scope": "invalid.deprecated",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Markdown Line Break",
+            "scope": "punctuation.definition.hard-line-break",
+            "background": "var(invisibles)"
+        }
+    ]
+}

--- a/Xcode Basic.sublime-color-scheme
+++ b/Xcode Basic.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"

--- a/Xcode Civic.sublime-color-scheme
+++ b/Xcode Civic.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"

--- a/Xcode Classic Dark.sublime-color-scheme
+++ b/Xcode Classic Dark.sublime-color-scheme
@@ -1,0 +1,324 @@
+{
+    "name": "Xcode Classic Dark",
+    "author": "Koen Lageveen, inspired by Apple",
+    "variables":
+    {
+        "plain_text"                    : "#FFFFFFD9",
+        "comments"                      : "#73A74E",
+        "documentation_markup"          : "#73A74E",
+        "documentation_markup_keywords" : "#A2E474",
+        "marks"                         : "#A2E474",
+        "strings"                       : "#FC6A5D",
+        "characters"                    : "#D0BF69",
+        "numbers"                       : "#D0BF69",
+        "keywords"                      : "#FC5FA3",
+        "preprocessor_statements"       : "#FD8F3F",
+        "urls"                          : "#5482FF",
+        "attributes"                    : "#BF8555",
+        "type_declarations"             : "#5DD8FF",
+        "other_declarations"            : "#41A1C0",
+        "project_class_names"           : "#9EF1DD",
+        "project_method_names"          : "#67B7A4",
+        "project_constants"             : "#67B7A4",
+        "project_type_names"            : "#9EF1DD",
+        "project_variables"             : "#67B7A4",
+        "project_preprocessor_macros"   : "#FD8F3F",
+        "other_class_names"             : "#D0A8FF",
+        "other_method_names"            : "#A167E6",
+        "other_constants"               : "#A167E6",
+        "other_type_names"              : "#D0A8FF",
+        "other_variables"               : "#A167E6",
+        "other_preprocessor_macros"     : "#FD8F3F",
+
+        "heading"                       : "#AA0D91",
+
+        "background"                    : "#1F1F24",
+        "current_line"                  : "#23252B",
+        "selection"                     : "#515B70",
+        "cursor"                        : "#FFFFFF",
+        "invisibles"                    : "#424D5B",
+
+        "embedded": "color(var(background) blend(var(invisibles) 86%))",
+        "invalid": "var(strings)",
+    },
+    "globals":
+    {
+        "foreground": "var(plain_text)",
+        "background": "var(background)",
+        "caret": "var(cursor)",
+        "line_highlight": "var(current_line)",
+        "selection": "var(selection)",
+        "selection_border": "color(var(selection) blend(#000 92%)",
+        "inactive_selection": "color(var(selection) blend(var(background) 72%)",
+        "misspelling": "var(strings)",
+        "shadow": "color(var(background) blend(#000 50%))"
+    },
+    "rules":
+    [
+        {
+            "name": "Error",
+            "scope": "markup.error",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Warning",
+            "scope": "markup.warning",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Parameters",
+            "scope": "variable.parameter",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.definition",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword, keyword.operator.word",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword.control.import",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Variables",
+            "scope": "variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Variable function",
+            "scope": "variable.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Functions",
+            "scope": "entity.name.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label)",
+            "foreground": "var(project_class_names)"
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Support Functions",
+            "scope": "support.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function.member",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "Support Classes",
+            "scope": "support.class",
+            "foreground": "var(other_class_names)"
+        },
+        {
+            "name": "Support Constants",
+            "scope": "support.constant, constant.language",
+            "foreground": "var(keywords)",
+            "font_style": "italic"
+        },
+        {
+            "name": "CSS Support Constants",
+            "scope": "source.css support.constant",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Strings, Inherited Class",
+            "scope": "string, entity.other.inherited-class",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "string punctuation.definition.string",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Variables in Strings",
+            "scope": "string variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.separator, punctuation.terminator, punctuation.accessor",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.section",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "foreground": "var(numbers)"
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "foreground": "var(project_constants)"
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Types",
+            "scope": "entity.name.type",
+            "foreground": "var(project_type_names)"
+        },
+        {
+            "name": "Types",
+            "scope": "support.type",
+            "foreground": "var(other_type_names)"
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "foreground": "var(project_constants)",
+            "font_style": "bold"
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold",
+            "font_style": "bold"
+        },
+        {
+            "name": "Italic",
+            "scope": "markup.italic",
+            "font_style": "italic"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw.inline",
+            "foreground": "var(preprocessor_statements)",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "markup.raw.inline punctuation.definition.raw",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Link Text",
+            "scope": "string.other.link, markup.underline.link",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Lists",
+            "scope": "punctuation.definition.list_item, markup.list.numbered.bullet",
+            "foreground": "var(documentation_markup)"
+        },
+        {
+            "name": "Quotes",
+            "scope": "punctuation.definition.blockquote",
+            "background": "var(invisibles)"
+        },
+        {
+            "name": "Link/Image Punctuation",
+            "scope": "punctuation.definition.image, punctuation.definition.link, punctuation.definition.metadata",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Inserted",
+            "scope": "markup.inserted",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Deleted",
+            "scope": "markup.deleted",
+            "foreground": "var(invalid)"
+        },
+        {
+            "name": "Changed",
+            "scope": "markup.changed",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Colors",
+            "scope": "constant.other.color",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions Operator",
+            "scope": "string.regexp keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "YAML String",
+            "scope": "source.yaml string.unquoted",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Embedded Variable",
+            "scope": "variable.interpolation",
+            "foreground": "var(project_preprocessor_macros)"
+        },
+        {
+            "name": "Illegal",
+            "scope": "invalid.illegal",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Invalid deprecated",
+            "scope": "invalid.deprecated",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Markdown Line Break",
+            "scope": "punctuation.definition.hard-line-break",
+            "background": "var(invisibles)"
+        }
+    ]
+}

--- a/Xcode Classic.sublime-color-scheme
+++ b/Xcode Classic.sublime-color-scheme
@@ -1,0 +1,323 @@
+{
+    "name": "Xcode Default",
+    "author": "Koen Lageveen, inspired by Apple",
+    "variables":
+    {
+        "plain_text"                    : "#000000D9",
+        "comments"                      : "#267507",
+        "documentation_markup"          : "#267507",
+        "documentation_markup_keywords" : "#267507",
+        "marks"                         : "#267507",
+        "strings"                       : "#C41A16",
+        "characters"                    : "#1C00CF",
+        "numbers"                       : "#1C00CF",
+        "keywords"                      : "#9B2393",
+        "preprocessor_statements"       : "#643820",
+        "urls"                          : "#0E0EFF",
+        "attributes"                    : "#815F03",
+        "type_declarations"             : "#0B4F79",
+        "other_declarations"            : "#0F68A0",
+        "project_class_names"           : "#1C464A",
+        "project_method_names"          : "#326D74",
+        "project_constants"             : "#326D74",
+        "project_type_names"            : "#1C464A",
+        "project_variables"             : "#326D74",
+        "project_preprocessor_macros"   : "#643820",
+        "other_class_names"             : "#3900A0",
+        "other_method_names"            : "#6C36A9",
+        "other_constants"               : "#6C36A9",
+        "other_type_names"              : "#3900A0",
+        "other_variables"               : "#6C36A9",
+        "other_preprocessor_macros"     : "#643820",
+        "heading"                       : "#AA0D91",
+
+        "background"                    : "#FFF",
+        "current_line"                  : "#E8F2FF",
+        "selection"                     : "#A4CDFF",
+        "cursor"                        : "#000",
+        "invisibles"                    : "#CCCCCC",
+
+        "embedded": "color(var(background) blend(var(invisibles) 86%))",
+        "invalid": "var(strings)",
+    },
+    "globals":
+    {
+        "foreground": "var(plain_text)",
+        "background": "var(background)",
+        "caret": "var(cursor)",
+        "line_highlight": "var(current_line)",
+        "selection": "var(selection)",
+        "selection_border": "color(var(selection) blend(#000 92%)",
+        "inactive_selection": "color(var(selection) blend(var(background) 72%)",
+        "misspelling": "var(strings)",
+        "shadow": "color(var(background) blend(#000 50%))"
+    },
+    "rules":
+    [
+        {
+            "name": "Error",
+            "scope": "markup.error",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Warning",
+            "scope": "markup.warning",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Parameters",
+            "scope": "variable.parameter",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.definition",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword, keyword.operator.word",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword.control.import",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Variables",
+            "scope": "variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Variable function",
+            "scope": "variable.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Functions",
+            "scope": "entity.name.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label)",
+            "foreground": "var(project_class_names)"
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Support Functions",
+            "scope": "support.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function.member",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "Support Classes",
+            "scope": "support.class",
+            "foreground": "var(other_class_names)"
+        },
+        {
+            "name": "Support Constants",
+            "scope": "support.constant, constant.language",
+            "foreground": "var(keywords)",
+            "font_style": "italic"
+        },
+        {
+            "name": "CSS Support Constants",
+            "scope": "source.css support.constant",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Strings, Inherited Class",
+            "scope": "string, entity.other.inherited-class",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "string punctuation.definition.string",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Variables in Strings",
+            "scope": "string variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.separator, punctuation.terminator, punctuation.accessor",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.section",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "foreground": "var(numbers)"
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "foreground": "var(project_constants)"
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Types",
+            "scope": "entity.name.type",
+            "foreground": "var(project_type_names)"
+        },
+        {
+            "name": "Types",
+            "scope": "support.type",
+            "foreground": "var(other_type_names)"
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "foreground": "var(project_constants)",
+            "font_style": "bold"
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold",
+            "font_style": "bold"
+        },
+        {
+            "name": "Italic",
+            "scope": "markup.italic",
+            "font_style": "italic"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw.inline",
+            "foreground": "var(preprocessor_statements)",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "markup.raw.inline punctuation.definition.raw",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Link Text",
+            "scope": "string.other.link, markup.underline.link",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Lists",
+            "scope": "punctuation.definition.list_item, markup.list.numbered.bullet",
+            "foreground": "var(documentation_markup)"
+        },
+        {
+            "name": "Quotes",
+            "scope": "punctuation.definition.blockquote",
+            "background": "var(invisibles)"
+        },
+        {
+            "name": "Link/Image Punctuation",
+            "scope": "punctuation.definition.image, punctuation.definition.link, punctuation.definition.metadata",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Inserted",
+            "scope": "markup.inserted",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Deleted",
+            "scope": "markup.deleted",
+            "foreground": "var(invalid)"
+        },
+        {
+            "name": "Changed",
+            "scope": "markup.changed",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Colors",
+            "scope": "constant.other.color",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions Operator",
+            "scope": "string.regexp keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "YAML String",
+            "scope": "source.yaml string.unquoted",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Embedded Variable",
+            "scope": "variable.interpolation",
+            "foreground": "var(project_preprocessor_macros)"
+        },
+        {
+            "name": "Illegal",
+            "scope": "invalid.illegal",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Invalid deprecated",
+            "scope": "invalid.deprecated",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Markdown Line Break",
+            "scope": "punctuation.definition.hard-line-break",
+            "background": "var(invisibles)"
+        }
+    ]
+}

--- a/Xcode Default Dark.sublime-color-scheme
+++ b/Xcode Default Dark.sublime-color-scheme
@@ -1,0 +1,324 @@
+{
+    "name": "Xcode Default Dark",
+    "author": "Koen Lageveen, inspired by Apple",
+    "variables":
+    {
+        "plain_text"                    : "#FFFFFFD9",
+        "comments"                      : "#6C7986",
+        "documentation_markup"          : "#6C7986",
+        "documentation_markup_keywords" : "#92A1B1",
+        "marks"                         : "#92A1B1",
+        "strings"                       : "#FC6A5D",
+        "characters"                    : "#D0BF69",
+        "numbers"                       : "#D0BF69",
+        "keywords"                      : "#FC5FA3",
+        "preprocessor_statements"       : "#FD8F3F",
+        "urls"                          : "#5482FF",
+        "attributes"                    : "#BF8555",
+        "type_declarations"             : "#5DD8FF",
+        "other_declarations"            : "#41A1C0",
+        "project_class_names"           : "#9EF1DD",
+        "project_method_names"          : "#67B7A4",
+        "project_constants"             : "#67B7A4",
+        "project_type_names"            : "#9EF1DD",
+        "project_variables"             : "#67B7A4",
+        "project_preprocessor_macros"   : "#FD8F3F",
+        "other_class_names"             : "#D0A8FF",
+        "other_method_names"            : "#A167E6",
+        "other_constants"               : "#A167E6",
+        "other_type_names"              : "#D0A8FF",
+        "other_variables"               : "#A167E6",
+        "other_preprocessor_macros"     : "#FD8F3F",
+
+        "heading"                       : "#AA0D91",
+
+        "background"                    : "#1F1F24",
+        "current_line"                  : "#23252B",
+        "selection"                     : "#515B70",
+        "cursor"                        : "#FFFFFF",
+        "invisibles"                    : "#424D5B",
+
+        "embedded": "color(var(background) blend(var(invisibles) 86%))",
+        "invalid": "var(strings)",
+    },
+    "globals":
+    {
+        "foreground": "var(plain_text)",
+        "background": "var(background)",
+        "caret": "var(cursor)",
+        "line_highlight": "var(current_line)",
+        "selection": "var(selection)",
+        "selection_border": "color(var(selection) blend(#000 92%)",
+        "inactive_selection": "color(var(selection) blend(var(background) 72%)",
+        "misspelling": "var(strings)",
+        "shadow": "color(var(background) blend(#000 50%))"
+    },
+    "rules":
+    [
+        {
+            "name": "Error",
+            "scope": "markup.error",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Warning",
+            "scope": "markup.warning",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Parameters",
+            "scope": "variable.parameter",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Comments",
+            "scope": "comment, punctuation.definition.comment",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation.definition",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Operators",
+            "scope": "keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword, keyword.operator.word",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Keywords",
+            "scope": "keyword.control.import",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Variables",
+            "scope": "variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Variable function",
+            "scope": "variable.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Functions",
+            "scope": "entity.name.function",
+            "foreground": "var(project_method_names)"
+        },
+        {
+            "name": "Classes",
+            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label)",
+            "foreground": "var(project_class_names)"
+        },
+        {
+            "name": "Storage",
+            "scope": "storage",
+            "foreground": "var(keywords)"
+        },
+        {
+            "name": "Support Functions",
+            "scope": "support.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function",
+            "foreground": "var(other_method_names)"
+        },
+        {
+            "name": "Method Call",
+            "scope": "meta.method-call variable.function.member",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "Support Classes",
+            "scope": "support.class",
+            "foreground": "var(other_class_names)"
+        },
+        {
+            "name": "Support Constants",
+            "scope": "support.constant, constant.language",
+            "foreground": "var(keywords)",
+            "font_style": "italic"
+        },
+        {
+            "name": "CSS Support Constants",
+            "scope": "source.css support.constant",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Strings, Inherited Class",
+            "scope": "string, entity.other.inherited-class",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "string punctuation.definition.string",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Variables in Strings",
+            "scope": "string variable",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.separator, punctuation.terminator, punctuation.accessor",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Misc Punctuation",
+            "scope": "punctuation.section",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Integers",
+            "scope": "constant.numeric",
+            "foreground": "var(numbers)"
+        },
+        {
+            "name": "Constants",
+            "scope": "constant",
+            "foreground": "var(project_constants)"
+        },
+        {
+            "name": "Tags",
+            "scope": "entity.name.tag",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Attributes",
+            "scope": "entity.other.attribute-name",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Types",
+            "scope": "entity.name.type",
+            "foreground": "var(project_type_names)"
+        },
+        {
+            "name": "Types",
+            "scope": "support.type",
+            "foreground": "var(other_type_names)"
+        },
+        {
+            "name": "Headings",
+            "scope": "markup.heading",
+            "foreground": "var(project_constants)",
+            "font_style": "bold"
+        },
+        {
+            "name": "Bold",
+            "scope": "markup.bold",
+            "font_style": "bold"
+        },
+        {
+            "name": "Italic",
+            "scope": "markup.italic",
+            "font_style": "italic"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Code",
+            "scope": "markup.raw.inline",
+            "foreground": "var(preprocessor_statements)",
+            "background": "var(embedded)"
+        },
+        {
+            "name": "Strings Punctuation",
+            "scope": "markup.raw.inline punctuation.definition.raw",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Link Text",
+            "scope": "string.other.link, markup.underline.link",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Lists",
+            "scope": "punctuation.definition.list_item, markup.list.numbered.bullet",
+            "foreground": "var(documentation_markup)"
+        },
+        {
+            "name": "Quotes",
+            "scope": "punctuation.definition.blockquote",
+            "background": "var(invisibles)"
+        },
+        {
+            "name": "Link/Image Punctuation",
+            "scope": "punctuation.definition.image, punctuation.definition.link, punctuation.definition.metadata",
+            "foreground": "var(urls)"
+        },
+        {
+            "name": "Inserted",
+            "scope": "markup.inserted",
+            "foreground": "var(comments)"
+        },
+        {
+            "name": "Deleted",
+            "scope": "markup.deleted",
+            "foreground": "var(invalid)"
+        },
+        {
+            "name": "Changed",
+            "scope": "markup.changed",
+            "foreground": "var(attributes)"
+        },
+        {
+            "name": "Colors",
+            "scope": "constant.other.color",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions",
+            "scope": "string.regexp",
+            "foreground": "var(characters)"
+        },
+        {
+            "name": "Regular Expressions Operator",
+            "scope": "string.regexp keyword.operator",
+            "foreground": "var(plain_text)"
+        },
+        {
+            "name": "Escape Characters",
+            "scope": "constant.character.escape",
+            "foreground": "var(other_preprocessor_macros)"
+        },
+        {
+            "name": "YAML String",
+            "scope": "source.yaml string.unquoted",
+            "foreground": "var(strings)"
+        },
+        {
+            "name": "Embedded Variable",
+            "scope": "variable.interpolation",
+            "foreground": "var(project_preprocessor_macros)"
+        },
+        {
+            "name": "Illegal",
+            "scope": "invalid.illegal",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Invalid deprecated",
+            "scope": "invalid.deprecated",
+            "foreground": "#FFF",
+            "background": "var(invalid)"
+        },
+        {
+            "name": "Markdown Line Break",
+            "scope": "punctuation.definition.hard-line-break",
+            "background": "var(invisibles)"
+        }
+    ]
+}

--- a/Xcode Default Dark.sublime-color-scheme
+++ b/Xcode Default Dark.sublime-color-scheme
@@ -92,7 +92,7 @@
         },
         {
             "name": "Keywords",
-            "scope": "keyword.control.import",
+            "scope": "keyword.control, keyword.control punctuation.definition",
             "foreground": "var(preprocessor_statements)"
         },
         {
@@ -112,13 +112,18 @@
         },
         {
             "name": "Classes",
-            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label)",
+            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label), variable.other.dollar.only.js",
             "foreground": "var(project_class_names)"
         },
         {
             "name": "Storage",
             "scope": "storage",
-            "foreground": "var(keywords)"
+            "foreground": "var(other_declarations)"
+        },
+        {
+            "name": "Function Storage",
+            "scope": "meta.function.declaration storage.type.function, storage.type.function keyword.declaration, storage.type.class keyword.declaration",
+            "foreground": "var(other_declarations)"
         },
         {
             "name": "Support Functions",
@@ -143,7 +148,7 @@
         {
             "name": "Support Constants",
             "scope": "support.constant, constant.language",
-            "foreground": "var(keywords)",
+            "foreground": "var(other_constants)",
             "font_style": "italic"
         },
         {
@@ -164,7 +169,7 @@
         {
             "name": "Variables in Strings",
             "scope": "string variable",
-            "foreground": "var(plain_text)"
+            "foreground": "var(other_variables)"
         },
         {
             "name": "Misc Punctuation",
@@ -178,7 +183,7 @@
         },
         {
             "name": "Integers",
-            "scope": "constant.numeric",
+            "scope": "constant.numeric, constant.numeric punctuation.separator",
             "foreground": "var(numbers)"
         },
         {
@@ -189,12 +194,12 @@
         {
             "name": "Tags",
             "scope": "entity.name.tag",
-            "foreground": "var(strings)"
+            "foreground": "var(project_class_names)"
         },
         {
             "name": "Attributes",
-            "scope": "entity.other.attribute-name",
-            "foreground": "var(attributes)"
+            "scope": "entity.other.attribute-name, entity.other.attribute-name punctuation.definition",
+            "foreground": "var(project_method_names)"
         },
         {
             "name": "Types",
@@ -207,9 +212,19 @@
             "foreground": "var(other_type_names)"
         },
         {
+            "name": "Types",
+            "scope": "entity.other support.type",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Types",
+            "scope": "entity.other.pseudo-element, entity.other.pseudo-element punctuation.definition, entity.other.pseudo-class, entity.other.pseudo-class punctuation.definition",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
             "name": "Headings",
             "scope": "markup.heading",
-            "foreground": "var(project_constants)",
+            "foreground": "var(heading)",
             "font_style": "bold"
         },
         {
@@ -275,7 +290,7 @@
         },
         {
             "name": "Colors",
-            "scope": "constant.other.color",
+            "scope": "constant.other.color, constant.other.color punctuation.definition",
             "foreground": "var(characters)"
         },
         {
@@ -301,7 +316,7 @@
         {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
-            "foreground": "var(project_preprocessor_macros)"
+            "foreground": "var(other_variables)"
         },
         {
             "name": "Illegal",

--- a/Xcode Default.sublime-color-scheme
+++ b/Xcode Default.sublime-color-scheme
@@ -3,35 +3,39 @@
     "author": "Koen Lageveen, inspired by Apple",
     "variables":
     {
-        "plain_text"                    : "#000",     // black
-        "comments"                      : "#008400",  // green
-        "documentation_markup"          : "#008400",  // green
-        "documentation_markup_keywords" : "#008400",  // green
-        "strings"                       : "#D12F1B",  // red
-        "characters"                    : "#272AD8",  // blue
-        "numbers"                       : "#272AD8",  // blue
-        "keywords"                      : "#BA2DA2",  // pink
-        "preprocessor_statements"       : "#78492A",  // dark brown
-        "urls"                          : "#1337FF",  // hot blue
-        "attributes"                    : "#957E35",  // light brown
-        "project_class_names"           : "#4F8187",  // light bondi
-        "project_method_names"          : "#31595D",  // dark bondi
-        "project_constants"             : "#31595D",  // dark bondi
-        "project_type_names"            : "#4F8187",  // light bondi
-        "project_variables"             : "#4F8187",  // light bondi
-        "project_preprocessor_macros"   : "#78492A",  // dark brown
-        "other_class_names"             : "#703DAA",  // purple
-        "other_method_names"            : "#3E1E81",  // light purple
-        "other_constants"               : "#3E1E81",  // light purple
-        "other_type_names"              : "#703DAA",  // purple
-        "other_variables"               : "#703DAA",  // purple
-        "other_preprocessor_macros"     : "#78492A",  // dark brown
+        "plain_text"                    : "#000000D9",
+        "comments"                      : "#5D6C79",
+        "documentation_markup"          : "#5D6C79",
+        "documentation_markup_keywords" : "#4A5560",
+        "marks"                         : "#4A5560",
+        "strings"                       : "#C41A16",
+        "characters"                    : "#1C00CF",
+        "numbers"                       : "#1C00CF",
+        "keywords"                      : "#9B2393",
+        "preprocessor_statements"       : "#643820",
+        "urls"                          : "#0E0EFF",
+        "attributes"                    : "#815F03",
+        "type_declarations"             : "#0B4F79",
+        "other_declarations"            : "#0F68A0",
+        "project_class_names"           : "#1C464A",
+        "project_method_names"          : "#326D74",
+        "project_constants"             : "#326D74",
+        "project_type_names"            : "#1C464A",
+        "project_variables"             : "#326D74",
+        "project_preprocessor_macros"   : "#643820",
+        "other_class_names"             : "#3900A0",
+        "other_method_names"            : "#6C36A9",
+        "other_constants"               : "#6C36A9",
+        "other_type_names"              : "#3900A0",
+        "other_variables"               : "#6C36A9",
+        "other_preprocessor_macros"     : "#643820",
+        "heading"                       : "#AA0D91",
 
-        "background"                    : "#FFF",     // white
-        "current_line"                  : "#EDF5FF",  // brighter blue
-        "selection"                     : "#B2D7FF",  // bright blue
-        "cursor"                        : "#000",     // black
-        "invisibles"                    : "#D6D6D6",  // grey
+        "background"                    : "#FFF",
+        "current_line"                  : "#E8F2FF",
+        "selection"                     : "#A4CDFF",
+        "cursor"                        : "#000",
+        "invisibles"                    : "#CCCCCC",
 
         "embedded": "color(var(background) blend(var(invisibles) 86%))",
         "invalid": "var(strings)",

--- a/Xcode Default.sublime-color-scheme
+++ b/Xcode Default.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"

--- a/Xcode Default.sublime-color-scheme
+++ b/Xcode Default.sublime-color-scheme
@@ -91,7 +91,7 @@
         },
         {
             "name": "Keywords",
-            "scope": "keyword.control.import",
+            "scope": "keyword.control, keyword.control punctuation.definition",
             "foreground": "var(preprocessor_statements)"
         },
         {
@@ -111,13 +111,18 @@
         },
         {
             "name": "Classes",
-            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label)",
+            "scope": "entity.name - (entity.name.section | entity.name.tag | entity.name.label), variable.other.dollar.only.js",
             "foreground": "var(project_class_names)"
         },
         {
             "name": "Storage",
             "scope": "storage",
-            "foreground": "var(keywords)"
+            "foreground": "var(other_declarations)"
+        },
+        {
+            "name": "Function Storage",
+            "scope": "meta.function.declaration storage.type.function, storage.type.function keyword.declaration, storage.type.class keyword.declaration",
+            "foreground": "var(other_declarations)"
         },
         {
             "name": "Support Functions",
@@ -142,7 +147,7 @@
         {
             "name": "Support Constants",
             "scope": "support.constant, constant.language",
-            "foreground": "var(keywords)",
+            "foreground": "var(other_constants)",
             "font_style": "italic"
         },
         {
@@ -163,7 +168,7 @@
         {
             "name": "Variables in Strings",
             "scope": "string variable",
-            "foreground": "var(plain_text)"
+            "foreground": "var(other_variables)"
         },
         {
             "name": "Misc Punctuation",
@@ -177,7 +182,7 @@
         },
         {
             "name": "Integers",
-            "scope": "constant.numeric",
+            "scope": "constant.numeric, constant.numeric punctuation.separator",
             "foreground": "var(numbers)"
         },
         {
@@ -188,12 +193,12 @@
         {
             "name": "Tags",
             "scope": "entity.name.tag",
-            "foreground": "var(strings)"
+            "foreground": "var(project_class_names)"
         },
         {
             "name": "Attributes",
-            "scope": "entity.other.attribute-name",
-            "foreground": "var(attributes)"
+            "scope": "entity.other.attribute-name, entity.other.attribute-name punctuation.definition",
+            "foreground": "var(project_method_names)"
         },
         {
             "name": "Types",
@@ -206,9 +211,19 @@
             "foreground": "var(other_type_names)"
         },
         {
+            "name": "Types",
+            "scope": "entity.other support.type",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
+            "name": "Types",
+            "scope": "entity.other.pseudo-element, entity.other.pseudo-element punctuation.definition, entity.other.pseudo-class, entity.other.pseudo-class punctuation.definition",
+            "foreground": "var(preprocessor_statements)"
+        },
+        {
             "name": "Headings",
             "scope": "markup.heading",
-            "foreground": "var(project_constants)",
+            "foreground": "var(heading)",
             "font_style": "bold"
         },
         {
@@ -274,7 +289,7 @@
         },
         {
             "name": "Colors",
-            "scope": "constant.other.color",
+            "scope": "constant.other.color, constant.other.color punctuation.definition",
             "foreground": "var(characters)"
         },
         {
@@ -300,7 +315,7 @@
         {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
-            "foreground": "var(project_preprocessor_macros)"
+            "foreground": "var(other_variables)"
         },
         {
             "name": "Illegal",

--- a/Xcode Dusk.sublime-color-scheme
+++ b/Xcode Dusk.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"

--- a/Xcode Low Key.sublime-color-scheme
+++ b/Xcode Low Key.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"

--- a/Xcode Midnight.sublime-color-scheme
+++ b/Xcode Midnight.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"

--- a/Xcode Sunset.sublime-color-scheme
+++ b/Xcode Sunset.sublime-color-scheme
@@ -294,11 +294,6 @@
             "foreground": "var(strings)"
         },
         {
-            "name": "Embedded",
-            "scope": "punctuation.section.embedded",
-            "foreground": "var(embedded)"
-        },
-        {
             "name": "Embedded Variable",
             "scope": "variable.interpolation",
             "foreground": "var(project_preprocessor_macros)"


### PR DESCRIPTION
This color scheme uses color data provided by xcode in the "~/Library/Developer/Xcode/UserData/FontAndColorThemes/" directory.
and was fine-tuned to feel like the default dark color scheme.

This should be available by default since it’s the most used color theme on xcode